### PR TITLE
Adicionando erros mais específicos

### DIFF
--- a/lib/gooder_data/api_client.rb
+++ b/lib/gooder_data/api_client.rb
@@ -132,6 +132,10 @@ module GooderData
       case response.code
       when BAD_REQUEST
         GooderData::ApiClient::BadRequestError
+      when UNAUTHORIZED
+        GooderData::ApiClient::Unauthorized
+      when NOT_FOUND
+        GooderData::ApiClient::NotFound
       else
         GooderData::ApiClient::Error
       end
@@ -139,7 +143,7 @@ module GooderData
 
     def error_message(response)
       error = response['error'] || {}
-      message = error['message'] || ""
+      message = error['message'] || response['message'] || ""
       parameters = error['parameters'] || []
 
       message % parameters

--- a/lib/gooder_data/errors.rb
+++ b/lib/gooder_data/errors.rb
@@ -16,6 +16,10 @@ module GooderData
 
     class BadRequestError < GooderData::ApiClient::Error; end
 
+    class Unauthorized < GooderData::ApiClient::Error; end
+
+    class NotFound < GooderData::ApiClient::Error; end
+
   end
 
 end

--- a/spec/cassettes/GooderData_SessionId/given_the_default_configuration/and_the_signer_was_not_given/should_sign_with_the_default_secret.yml
+++ b/spec/cassettes/GooderData_SessionId/given_the_default_configuration/and_the_signer_was_not_given/should_sign_with_the_default_secret.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://developer.gooddata.com/downloads/sso/gooddata-sso.pub
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 15 Mar 2016 12:15:46 GMT
+      Server:
+      - Apache
+      Last-Modified:
+      - Tue, 26 May 2015 14:05:25 GMT
+      Etag:
+      - '"5a5f50-6ca-516fc9e2f8324"'
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '1749'
+      Content-Type:
+      - text/plain
+      Vary:
+      - Accept-Encoding, User-Agent
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: GnuPG v2.0.14 (GNU/Linux)
+
+        mQENBExqdtABCAD4YZcUozx4vLtPWFbcpQt6/iBZQAs98d0JUGNy0szVQ2Ydm3zV
+        vDqdxUxNkTK8/BRxTZ3i4C+D7nmQm2Zn3eByUNszxLLLKgpxtGQ2ntWNfKwpPyuk
+        JkqjVrPvH3Naxn/jrm/hNZTq2DRWwqc33+XJbVGX7Br9ZeTTI3logp8PDN9jJrvE
+        DKGO+hwfI+6tsu1O5/zzAUfMRuqOK+N2Dj+CBE6HTqhRLPkU0UMVcuBXDUBWvjFV
+        Lc8GW5kM0RzPTEx/iFk/o0mEM7Gzv6SxUDCx+kpAbOLuKl8Ke1ThFlm48mIPyXan
+        htVjkyjEi/TxdAR1Swj+c7MoSqmQW52CqMi1ABEBAAG0JEdvb2REYXRhIFNTTyA8
+        c2VjdXJpdHlAZ29vZGRhdGEuY29tPokBPgQTAQIAKAIbAwYLCQgHAwIGFQgCCQoL
+        BBYCAwECHgECF4AFAlVe64QFCRJadjQACgkQh3ssRyBDQfXlDAgAyX/jQm+QyLA3
+        QPxowhd+Cq1Eogb5YBxAt+MD6Hj4Hleukqj08eCUvZUenxg8cSBdEbwkqxgOYfQE
+        iQrSXkczPQgWxNVaHSfzxheqD1wTMT7cQCEJkGeR3vbGP2GUBm7Hw+8sygIug+JH
+        Vl6zw8QMMVjHVcUOeF8TNeWBGaaGWEZ2bYTiQZsuZUkOce7nF2QsJm/Nc754LGVA
+        IECEKzLS/yBXo5aiac1qAFVq5xn8XTK3l304LHwabHakCUsNyaAyAYlmrbkvDuNh
+        /N1PPCsg7BU1KF8fKZveQ9ji1ZI0vbhGo02v0gBpinW/xV/92ZfOh6v1CL2pYDdb
+        +Qrrpy58I7kBDQRManbQAQgAxT7B5I0xXXaSewUMCncE1lDnTxDv/kMv2oqgf4yc
+        WKp2XRmJTS2lOhZAL5//n4FJxm0vfE++A1pLtAJ41nTfe6AOfYmXuOrKuibjJD93
+        aG3rp2a8wQRMTVXKO/5QLZYSylTlGTIuUHx2ME2VLaq48Bq1BsAa8Z8WUI5Ghcsx
+        E5XDedYZknUb1ORiCmW07Ms8tV8Dz7slDkVn+lfiL4wHTKduo/wLnzDX8b3AEYqo
+        LOhg2WbT/WaB4RZSyxXXvodvaxggYmWV2TCk+7EZy3uZuPu9H5HZlFET8HB34tZB
+        OFuYEx7ryKtp8XYPeMl40Bfly1EMbWlkkixVODMqTSEQzwARAQABiQElBBgBAgAP
+        AhsMBQJVXuuUBQkSWnZEAAoJEId7LEcgQ0H1mqAIAKDygPawfuM9Zh8mVEjsRGlv
+        E+TuNwFQSZ1ua7McnGx3dyajHrxd3IqBLZTrAwR4TXI0azLnoH08xKANbGa9TjiT
+        0EKQ5hi04EgQjYmFiATGUjtYWoUKq2yfcCNB+ba7hJtgw+OAGirUaf1Xe5O/9b2a
+        1neuiI1sSVCQNQJZ/UyWMgJPtZqQ/R2H+/XRetz9ab7i0uYZgyHC5ksWqS+ThWpB
+        daqBA46jNce/Vj8nOsg5zJwsLbCRjcpgFp7Upcm7XP+rdW7J8hgWaEAmFCCrIuXX
+        Uu54VLoDtkIy0E7vGWvm0Cvqfil87mWy1nB6LJYfKWUHcgYkUF1NVxHYyo3Z0W4=
+        =TX2T
+        -----END PGP PUBLIC KEY BLOCK-----
+    http_version: 
+  recorded_at: Tue, 15 Mar 2016 12:15:46 GMT
+recorded_with: VCR 3.0.1

--- a/spec/lib/gooder_data/session_id_spec.rb
+++ b/spec/lib/gooder_data/session_id_spec.rb
@@ -52,7 +52,7 @@ describe GooderData::SessionId, :vcr do
       context "and the password was given" do
         let(:password) { "my custom password" }
         it "should sign with the given signer's secret and password" do
-          expect(@crypto).to receive(:sign).with(anything, { armor: true, signer: signer, password: password })
+          expect(@crypto).to receive(:sign).with(anything, { armor: true, signer: signer, passphrase: password })
           GooderData::SessionId.new(user_email, sso_signer_email: signer, sso_signer_password: password).to_url
         end
       end


### PR DESCRIPTION
# Motificação

+ Com o objetivo de realizar tratamentos de erros mais específicos foi adicionada novas exceptions baseadas nos códigos de erros padronizados do http.

+ Nem sempre que o response contém um código de erro, códigos que não comecem com 2, é retornado um objeto erro com uma mensagem. Por isso, foi necessário alterar  [`error_message`](https://github.com/ResultadosDigitais/gooder_data/blob/b3b71241b8a41e0e2a0c33e508a4c5cd9aa62f42/lib/gooder_data/api_client.rb#L144-L150) para incluir a mensagem geral se não houver o objeto error.