### PR TITLE
Change access to response URI.

### DIFF
--- a/lib/gooder_data/project/report.rb
+++ b/lib/gooder_data/project/report.rb
@@ -92,7 +92,7 @@ module GooderData
             }
           })
         end.responds do |response|
-          "https://secure.gooddata.com#{(try_hash_chain(response, "uri") || '').to_s}"
+          "https://secure.gooddata.com#{ response.with_indifferent_access.try(:[], :uri) || ''}"
         end
       end
 
@@ -103,7 +103,6 @@ module GooderData
         end
         response
       end
-
     end
   end
 end


### PR DESCRIPTION
This change was necessary due to the fact that we were getting a nil
value from the response of the export request.

As long as the response is no longer a Hash class, but a
HTTParty::Response, I changed the call to the method `#try_hash_chain`
to `#try`.