### PR TITLE
Fix data_fetch_url method, after httparty gem update

### DIFF
--- a/lib/gooder_data/project/report.rb
+++ b/lib/gooder_data/project/report.rb
@@ -70,7 +70,7 @@ module GooderData
       private
 
       def data_fetch_url
-        @data_fetch_url ||= (try_hash_chain(execute, 'execResult', 'dataResult') || '').gsub(/^\/gdc/, '')
+        @data_fetch_url ||= (try_hash_chain(execute.parsed_response, 'execResult', 'dataResult') || '').gsub(/^\/gdc/, '')
       end
 
       def execute


### PR DESCRIPTION
Fix data_fetch_url method, after httparty gem update. Now, httparty does not returns a hash
